### PR TITLE
Added button that can change the app theme and works even when app is…

### DIFF
--- a/app/src/main/java/com/example/fumolizer/SettingsActivity.kt
+++ b/app/src/main/java/com/example/fumolizer/SettingsActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.app.Activity
 import android.content.ComponentName
 import android.content.Intent
+import android.content.SharedPreferences
 import android.media.MediaMetadata
 import android.view.View
 import android.view.View.OnClickListener
@@ -17,6 +18,7 @@ import android.media.MediaPlayer
 import android.media.session.MediaSessionManager
 import android.os.Handler
 import android.util.Log
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.getSystemService
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import java.lang.AssertionError
@@ -29,17 +31,34 @@ class SettingsActivity : AppCompatActivity() {
 
         // TO-DO: Find a way to get the current song information here!
 
-        /*val tester = findViewById(R.id.button_settings_test) as Button
-        tester.setOnClickListener {
-            val m = getSystemService<MediaSessionManager>()!!
-            val component = ComponentName(this, NotiService::class.java)
-            val sessions = m.getActiveSessions(component)
-            Log.d("Sessions", "count: ${sessions.size}")
-            sessions.forEach {
-                Log.d("Sessions", "$it -- " + (it?.metadata?.keySet()?.joinToString()))
-                Log.d("Sessions", "$it -- " + (it?.metadata?.getString(MediaMetadata.METADATA_KEY_TITLE)))
+        // Changes theme of application
+        var button = findViewById<Button>(R.id.button_settings_darkMode)
+
+        val appSettingPrefs: SharedPreferences = getSharedPreferences( "AppSettingsPrefs", 0)
+        val sharedPrefsEdit: SharedPreferences.Editor = appSettingPrefs.edit()
+        val isNightModeOn: Boolean = appSettingPrefs.getBoolean( "NightMode", false)
+
+        if(isNightModeOn) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+            button.text = "Disable Dark Mode"
+        } else {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+            button.text = "Enable Dark Mode"
+        }
+        button.setOnClickListener {
+            if(isNightModeOn) {
+                button.text = "Enable Dark Mode"
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+                sharedPrefsEdit.putBoolean("NightMode", false)
+                sharedPrefsEdit.apply()
             }
-        }*/
+            else {
+                button.text = "Disable Dark Mode"
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+                sharedPrefsEdit.putBoolean("NightMode", true)
+                sharedPrefsEdit.apply()
+            }
+        }
 
 
         findViewById<BottomNavigationView>(R.id.bottom_navigation).selectedItemId = R.id.ic_settings

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -18,10 +18,10 @@
 
 
             <Button
-                android:id="@+id/button_settings_test"
+                android:id="@+id/button_settings_darkMode"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Button"
+                android:text="Enable Dark Mode"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
… closed, but not when it's swiped up. When app is swiped up, it turns back to normal but once you go to settings, it turns it back to dark theme. Perhaps do something with what David did to keep the equalizer controls working, not sure what it is. But, dark theme does work.